### PR TITLE
Allow returning unused tokens by charging negative amount

### DIFF
--- a/lib/redis_token_bucket/limiter.lua
+++ b/lib/redis_token_bucket/limiter.lua
@@ -27,10 +27,10 @@ for key_index, key in ipairs(KEYS) do
 
   current_bucket_levels[key_index] = current_level
 
-  if amount > 0 then
+  if amount ~= 0 then
     local limit = tonumber(ARGV[arg_index + 3]) or 0
 
-    local new_level = current_level - amount
+    local new_level = math.min(size, current_level - amount)
 
     local seconds_to_full = (size - new_level) / rate
     timeouts[key_index] = seconds_to_full

--- a/lib/redis_token_bucket/limiter.rb
+++ b/lib/redis_token_bucket/limiter.rb
@@ -30,13 +30,6 @@ class Limiter
   # `success:boolean` and `levels:Hash<String, Numeric>`
   # where `levels` is a hash from bucket keys to bucket levels.
   def batch_charge(*charges)
-    charges.each do |(bucket, amount, options)|
-      unless amount > 0
-        message = "tried to charge #{amount}, needs to be Numeric and > 0"
-        raise ArgumentError, message
-      end
-    end
-
     run_script(charges)
   end
 


### PR DESCRIPTION
We're using TokenBucketLimiter for throttling GraphQL Shopify requests. We're estimating request cost and charging that much from the bucket. Responses contain actual cost, which is usually lower due to fewer results. We'd like to calculate difference and return unused tokens.